### PR TITLE
Fix comparison in image size check

### DIFF
--- a/mkfs/mkfs-ouichefs.c
+++ b/mkfs/mkfs-ouichefs.c
@@ -335,7 +335,7 @@ int main(int argc, char **argv)
 
 	/* Check if image is large enough */
 	min_size = 100 * OUICHEFS_BLOCK_SIZE;
-	if (stat_buf.st_size <= min_size) {
+	if (stat_buf.st_size < min_size) {
 		fprintf(stderr,
 			"File is not large enough (size=%ld, min size=%ld)\n",
 			stat_buf.st_size, min_size);


### PR DESCRIPTION
When creating the smallest possible img the following error occurs:

```zsh
❯ make img
rm -rf smol.img
dd if=/dev/zero of=smol.img bs=1K count=400
400+0 records in
400+0 records out
409600 bytes transferred in 0.002154 secs (190157846 bytes/sec)
./mkfs.ouichefs smol.img
File is not large enough (size=409600, min size=409600)
make: *** [Makefile:17: img] Error 1
```

`File is not large enough (size=409600, min size=409600)` doesn't make sense.

```diff
- if (stat_buf.st_size <= min_size) {
+ if (stat_buf.st_size < min_size) {
```

Fixes it